### PR TITLE
Update to OAuth 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "6.1.0"
+  - "5.11.0"
+  - "4.4.0"
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hubot Fitbit Leaders [![npm version](https://badge.fury.io/js/hubot-fitbit-leaders.svg)](http://badge.fury.io/js/hubot-fitbit-leaders) [![Build Status](https://travis-ci.org/stephenyeargin/hubot-fitbit-leaders.png)](https://travis-ci.org/stephenyeargin/hubot-fitbit-leaders)
+# Hubot Fitbit Leaders v2 [![npm version](https://badge.fury.io/js/hubot-fitbit-leaders.svg)](http://badge.fury.io/js/hubot-fitbit-leaders) [![Build Status](https://travis-ci.org/stephenyeargin/hubot-fitbit-leaders.png)](https://travis-ci.org/stephenyeargin/hubot-fitbit-leaders)
 
 This script is designed to be used with a [Hubot](http://hubot.github.com) to compare the Fitbit activity of your friends.
 
@@ -11,21 +11,40 @@ See full instructions [here](https://github.com/github/hubot/blob/master/docs/sc
 
 ## Commands
 
+- `hubot fitbit setup` - Run through the setup process for the bot (for admins)
 - `hubot fitbit leaders` - Show table of leaders
 - `hubot fitbit register` - Show how to friend the bot
 - `hubot fitbit approve` - Approve all pending requests
 
+## Upgrading from 1.0.x?
+
+You will need to update your `FITBIT_CLIENT_ID` and generate a new `FITBIT_OAUTH_TOKEN` using the steps below. You no longer need the `FITBIT_OAUTH_TOKEN_SECRET` configuration variable. Note that you will have to go through this process at least once a year (the Implicit grant type token is time-limited.)
+
+## Configuration
+
+| Environment Variable   | Description                                     |
+| -----------------------| ------------------------------------------------|
+| `FITBIT_CLIENT_ID`     | Obtained from the app registration.             | 
+| `FITBIT_CLIENT_SECRET` | Obtained from the app registration.             | 
+| `FITBIT_OAUTH_TOKEN`   | Found in the callback response, lasts one year. | 
+
+Register the three values as environment variables when starting your bot (as usual with Hubot scripts) using `export` or `heroku config:set` or whatever applies to your Hubot hosting environment.
+
 ## Suggested Setup
 
 * Decide whether you want to use a user account or create a "robot" account to use with Fitbit
-* Go to the [Fitbit Developer App Registration Page](https://dev.fitbit.com/apps/new) and create a new app using settings similar to these: ![Fitbit New App Form](http://i.imgur.com/JEnSON1.png)
-* You should now see a screen similar to this one which you will need to keep open for the next step: ![Fitbit App Summary](http://i.imgur.com/H0Sf10E.png)
-* Sign up for a free account with [Runscope](https://www.runscope.com) and once signed in visit their free [OAuth 1.0a Token Generator](https://www.runscope.com/oauth1_tool).
-* Fill in the form with the consumer key and secret from the Fitbit Application you registered above like so: ![Runscope OAuth 1.0a Token Generator](http://i.imgur.com/ABOe4F5.png)
-* Click Generate Token and you'll be redirected to a screen like this one: ![Runscope OAuth 1.0a Token Generator Success Page](http://i.imgur.com/vz3aJTz.png)
-* The form fields presented there are, in order, the following Hubot environment variables:
- * `FITBIT_CLIENT_ID`
- * `FITBIT_CLIENT_SECRET`
- * `FITBIT_OAUTH_TOKEN`
- * `FITBIT_OAUTH_TOKEN_SECRET`
-* Register the four values as environment variables when starting your bot (as usual with Hubot scripts) using `export` or `heroku config:set` or whatever applies to your Hubot hosting environment.
+* Go to the [Fitbit Developer App Registration Page](https://dev.fitbit.com/apps/new) and register an application
+ * The "Callback URL" field can be any running public web server. I prefer to use a [RunScope](https://runscope.com) bucket.
+ * The "OAuth 2.0 Application Type: is "Client"
+ * The application will need "Read & Write" access (for friend requests)
+* Note the Client ID and Client Secret. Go ahead and add those to your configuration file and restart Hubot.
+* Run the Fitbit setup command, e.g. `hubot fitbit setup`
+* A URL will be displayed that contains your configured Client ID, but is missing the registered callback URL. Plug that in, then go through the authorization steps.
+* Upon a successful authorization, the URL will appear in your browser containing your access token. It's very long, so make sure you grab everything between the `=` and the next `&`. Place these values into your configuration and restart Hubot.
+* If all went well, type `hubot register` and see if you receive a response.
+
+## Troubleshooting
+
+- Remember that the token expires after a year, so be prepared to go through these steps at least that often (replacing the Access Token).
+- Double check your saved configuration to make sure it matches the values displayed in the Fitbit application.
+- The callback step is a bit tricky. The few times I've run it, I ended up with a server error, but was still able to retrieve the Access Token from the URL.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "hubot-fitbit-leaders",
-  "description": "Fitbit leaderboards",
+  "description": "Hubot Fitbit Leaders",
   "version": "1.1.0",
   "author": "Stephen Yeargin <stephen@yearg.in>",
-  "homepage": "https://github.com/hubot-scripts/hubot-fitbit-leaders",
+  "homepage": "https://github.com/stephenyeargin/hubot-fitbit-leaders",
   "license": "MIT",
   "keywords": [
     "hubot",
@@ -12,14 +12,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/hubot-scripts/hubot-fitbit-leaders"
+    "url": "https://github.com/stephenyeargin/hubot-fitbit-leaders"
   },
   "bugs": {
-    "url": "https://github.com/hubot-scripts/hubot-fitbit-leaders/issues"
+    "url": "https://github.com/stephenyeargin/hubot-fitbit-leaders/issues"
   },
   "dependencies": {
-    "fitbit-js": "0.3.0",
-    "moment": "2.10.6"
+    "fitbit-node": "^2.0.1",
+    "moment": "^2.14.1"
   },
   "devDependencies": {
     "chai": "^2.1.1",

--- a/test/hubot-fitbit-leaders_test.coffee
+++ b/test/hubot-fitbit-leaders_test.coffee
@@ -15,6 +15,9 @@ describe 'hubot-fitbit-leaders', ->
   it 'registers a respond listener for fitbit', ->
     expect(@robot.respond).to.have.been.calledWith(/fitbit$/i)
 
+  it 'registers a respond listener for fitbit setup', ->
+    expect(@robot.respond).to.have.been.calledWith(/fitbit (?:token|setup)$/i)
+
   it 'registers a respond listener for fitbit friends', ->
     expect(@robot.respond).to.have.been.calledWith(/fitbit friends/i)
 


### PR DESCRIPTION
Fixes #6

This introduces a few breaking changes, but the good news is that your installations were already broken because of the protocol upgrade. :sweat_smile:

The README has been updated to reflect the necessary changes and steps to go through in obtaining an "Implicit Grant Flow" token. The big difference here is that while the OAuth 1.0a tokens would last forever, these expire after a year. This is slightly better than the normal "Authorization Code Grant Flow" which would issue a token and a refresh that only lasted a few hours at most.

You will definitely need to update:

- Your `FITBIT_CLIENT_ID`
- Your `FITBIT_OAUTH_TOKEN`

To accomplish this, I needed to swap out the underlying library to talk to Fitbit. This means error handling and other conditions likely broke, so please file issues with reporduction steps after this merges if you run into edge cases.