### PR TITLE
Fix bad reference to API response

### DIFF
--- a/src/hubot-fitbit-leaders.coffee
+++ b/src/hubot-fitbit-leaders.coffee
@@ -70,7 +70,7 @@ module.exports = (robot) ->
   robot.respond /fitbit register/i, (msg) ->
     Fitbit.get('/profile.json', accessToken)
     .then (res) ->
-      robot.logger.debug json
+      robot.logger.debug res
       user = getResponseBody(res).user
       unless user.fullName
         user.fullName = 'the bot'
@@ -82,7 +82,7 @@ module.exports = (robot) ->
   robot.respond /fitbit approve/i, (msg) ->
     Fitbit.get('/friends/invitations.json', accessToken)
     .then (res) ->
-      robot.logger.debug json
+      robot.logger.debug res
       if getResponseBody(res).friends.length is 0
         msg.send "No pending requests."
         return


### PR DESCRIPTION
Fixes a bug where everything _other_ that `hubot fitbit leaders` would return an error because the `json` variable isn't defined. Bad code, needs tests.