### PR TITLE
 Fix help text for expired token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-fitbit-leaders",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-fitbit-leaders",
   "description": "Hubot Fitbit Leaders",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Stephen Yeargin <stephen@yearg.in>",
   "homepage": "https://github.com/stephenyeargin/hubot-fitbit-leaders",
   "license": "MIT",

--- a/src/fitbit-leaders.coffee
+++ b/src/fitbit-leaders.coffee
@@ -153,7 +153,7 @@ module.exports = (robot) ->
   displayErrors = (err, msg) ->
     for own key, error of err.errors
       if error.errorType == 'expired_token'
-        msg.send "Your Fitbit token has expired! See `#{robot.name} token` to set up a new one."
+        msg.send "Your Fitbit token has expired! See `#{robot.name} fitbit token` to set up a new one."
       else
         robot.logger.error err
         msg.send error.message

--- a/test/fitbit-leaders_test.coffee
+++ b/test/fitbit-leaders_test.coffee
@@ -156,7 +156,7 @@ describe 'hubot-fitbit-leaders', ->
         try
           expect(selfRoom.messages).to.eql [
             ['alice', '@hubot fitbit leaders']
-            ['hubot', 'Your Fitbit token has expired! See `hubot token` to set up a new one.']
+            ['hubot', 'Your Fitbit token has expired! See `hubot fitbit token` to set up a new one.']
           ]
           done()
         catch err


### PR DESCRIPTION
Changes `hubot token` to `hubot fitbit token`, which will actually fire.