### PR TITLE
Bump versions, configure release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,7 +1,7 @@
 {
   "pkgFiles": ["package.json", "package-lock.json"],
-  "src": {
-    "tagName": "v%s"
+  "git": {
+    "tagName": "v${version}"
   },
   "github": {
     "release": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 notifications:
   email: false
 node_js:
-  - "10" # stable
-  - "8"  # LTS
-  - "6"  # maintenance
+  - "12" # stable
+  - "10" # LTS
+  - "8"  # maintenance
 cache:
   directories:
     - node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,6 +2319,12 @@
           "requires": {
             "lodash": "^4.17.10"
           }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
         }
       }
     },
@@ -3423,9 +3429,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash.find": {
@@ -3837,9 +3843,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
     "url": "https://github.com/stephenyeargin/hubot-fitbit-leaders/issues"
   },
   "dependencies": {
-    "fitbit-node": "^2.1.0",
-    "moment": "^2.22.2"
+    "fitbit-node": "^2.2.0",
+    "moment": "^2.24.0"
   },
   "peerDependencies": {
-    "hubot": ">=2 <10 || 0.0.0-development"
+    "hubot": "^3"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "coffee-script": "^1.12.7",
-    "grunt": "^1.0.3",
-    "grunt-cli": "^1.2.0",
+    "grunt": "^1.0.4",
+    "grunt-cli": "^1.3.2",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-mocha-test": "~0.13.3",
     "hubot-test-helper": "^1.9.0",
@@ -38,7 +38,7 @@
     "nock": "^10.0.6",
     "release-it": "^12.3.0",
     "sinon": "^7.3.2",
-    "sinon-chai": "^3.2.0"
+    "sinon-chai": "^3.3.0"
   },
   "main": "index.coffee",
   "scripts": {

--- a/src/fitbit-leaders.coffee
+++ b/src/fitbit-leaders.coffee
@@ -1,10 +1,6 @@
 # Description:
 #   Fitbit leaderboards
 #
-# Dependencies:
-#  "fitbit-node": "^2.0.2"
-#  "moment": "^2.14.1"
-#
 # Configuration:
 #  FITBIT_CLIENT_ID
 #  FITBIT_CLIENT_SECRET


### PR DESCRIPTION
A few more changes after version bumps:

- Configure release-it with new values
- Bump versions that still had security alerts
- Fixes https://nvd.nist.gov/vuln/detail/CVE-2018-16487